### PR TITLE
Add token expiration management.

### DIFF
--- a/multitoken/authentication.py
+++ b/multitoken/authentication.py
@@ -1,6 +1,14 @@
-from rest_framework import authentication
+from django.utils.translation import ugettext_lazy as _
+from rest_framework import authentication, exceptions
 from . import models
 
 
 class TokenAuthentication(authentication.TokenAuthentication):
     model = models.Token
+
+    def authenticate_credentials(self, key):
+        token_user, token = super(
+            TokenAuthentication, self).authenticate_credentials(key)
+        if token.is_expired:
+            raise exceptions.AuthenticationFailed(_('invalid_token'))
+        return token_user, token

--- a/multitoken/models.py
+++ b/multitoken/models.py
@@ -1,4 +1,5 @@
 import binascii
+import datetime
 import os
 from django.conf import settings
 from django.db import models
@@ -16,6 +17,13 @@ class Token(models.Model):
             'client',
         )
 
+    def __unicode__(self):
+        return u'{0} (client: {1})'.format(self.key, self.client)
+
+    LOGIN_FIELDS = (
+        'client',
+    )
+
     def save(self, *args, **kwargs):
         if not self.key:
             self.key = self.generate_key()
@@ -24,9 +32,7 @@ class Token(models.Model):
     def generate_key(self):
         return binascii.hexlify(os.urandom(20)).decode()
 
-    def __unicode__(self):
-        return u'{0} (client: {1})'.format(self.key, self.client)
-
-    LOGIN_FIELDS = (
-        'client',
-    )
+    @property
+    def is_expired(self):
+        token_timeout = settings.REST_MULTITOKEN['TOKEN_TIMEOUT']
+        return self.created < datetime.datetime.utcnow() - token_timeout

--- a/multitoken/settings.py
+++ b/multitoken/settings.py
@@ -1,0 +1,18 @@
+from datetime import timedelta
+from django.core.exceptions import ImproperlyConfigured
+
+
+TOKEN_TIMEOUT_IN_DAYS = 14
+
+
+def get(key):
+    from django.conf import settings
+    defaults = {
+        'TOKEN_TIMEOUT': timedelta(days=TOKEN_TIMEOUT_IN_DAYS)
+    }
+    defaults.update(getattr(settings, 'REST_MULTITOKEN', {}))
+    try:
+        return defaults[key]
+    except KeyError:
+        raise ImproperlyConfigured(
+            'Missing settings: REST_MULTITOKEN[\'{}\']'.format(key))

--- a/multitoken/views.py
+++ b/multitoken/views.py
@@ -14,7 +14,7 @@ class ObtainTokenView(generics.GenericAPIView):
     token_serializer_class = serializers.TokenSerializer
 
     def post(self, request):
-        serializer = self.get_serializer(data=request.DATA)
+        serializer = self.get_serializer(data=request.data)
         if serializer.is_valid():
             return self.login(serializer)
         else:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 -e .
 djet>=0.0.10
+freezegun


### PR DESCRIPTION
Late child of interview session.
This version is just a scratch; should be developed with some management of expired tokens (more than just raising an exception).
